### PR TITLE
Fixing README badges

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,7 +72,9 @@ jobs:
         run:
           tox run -e py
       - name: Upload coverage report to codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         if: success()
         with:
           file: coverage.xml
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
         <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/oncvpsp_tools" />
     </a>
     <a href="https://github.com/pseudopotential-tools/oncvpsp-tools/blob/main/LICENSE">
-        <img alt="PyPI - License" src="https://img.shields.io/pypi/l/oncvpsp_tools" />
+        <img alt="PyPI - License" src="https://img.shields.io/pypi/l/oncvpsp-tools" />
     </a>
     <a href='https://oncvpsp_tools.readthedocs.io/en/latest/?badge=latest'>
         <img src='https://readthedocs.org/projects/oncvpsp_tools/badge/?version=latest' alt='Documentation Status' />

--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@
         <img alt="Tests" src="https://github.com/pseudopotential-tools/oncvpsp-tools/workflows/Tests/badge.svg" />
     </a>
     <a href="https://pypi.org/project/oncvpsp_tools">
-        <img alt="PyPI" src="https://img.shields.io/pypi/v/oncvpsp_tools" />
+        <img alt="PyPI" src="https://img.shields.io/pypi/v/oncvpsp-tools" />
     </a>
     <a href="https://pypi.org/project/oncvpsp_tools">
-        <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/oncvpsp_tools" />
+        <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/oncvpsp-tools" />
     </a>
     <a href="https://github.com/pseudopotential-tools/oncvpsp-tools/blob/main/LICENSE">
         <img alt="PyPI - License" src="https://img.shields.io/pypi/l/oncvpsp-tools" />

--- a/README.md
+++ b/README.md
@@ -10,32 +10,23 @@
 
 <p align="center">
     <a href="https://github.com/pseudopotential-tools/oncvpsp-tools/actions/workflows/tests.yml">
-        <img alt="Tests" src="https://github.com/pseudopotential-tools/oncvpsp-tools/workflows/Tests/badge.svg"/>
-    </a>
+        <img alt="Tests" src="https://github.com/pseudopotential-tools/oncvpsp-tools/workflows/Tests/badge.svg"/></a>
     <a href="https://pypi.org/project/oncvpsp_tools">
-        <img alt="PyPI" src="https://img.shields.io/pypi/v/oncvpsp-tools"/>
-    </a>
+        <img alt="PyPI" src="https://img.shields.io/pypi/v/oncvpsp-tools"/></a>
     <a href="https://pypi.org/project/oncvpsp_tools">
-        <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/oncvpsp-tools"/>
-    </a>
+        <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/oncvpsp-tools"/></a>
     <a href="https://github.com/pseudopotential-tools/oncvpsp-tools/blob/main/LICENSE">
-        <img alt="PyPI - License" src="https://img.shields.io/pypi/l/oncvpsp-tools"/>
-    </a>
+        <img alt="PyPI - License" src="https://img.shields.io/pypi/l/oncvpsp-tools"/></a>
     <a href='https://oncvpsp_tools.readthedocs.io/en/latest/?badge=latest'>
-        <img src='https://readthedocs.org/projects/oncvpsp_tools/badge/?version=latest' alt='Documentation Status'/>
-    </a>
+        <img src='https://readthedocs.org/projects/oncvpsp_tools/badge/?version=latest' alt='Documentation Status'/></a>
     <a href="https://codecov.io/gh/pseudopotential-tools/oncvpsp-tools/branch/main">
-        <img src="https://codecov.io/gh/pseudopotential-tools/oncvpsp-tools/branch/main/graph/badge.svg" alt="Codecov status"/>
-    </a>  
+        <img src="https://codecov.io/gh/pseudopotential-tools/oncvpsp-tools/branch/main/graph/badge.svg" alt="Codecov status"/></a>  
     <a href="https://github.com/cthoyt/cookiecutter-python-package">
-        <img alt="Cookiecutter template from @cthoyt" src="https://img.shields.io/badge/Cookiecutter-snekpack-blue"/> 
-    </a>
+        <img alt="Cookiecutter template from @cthoyt" src="https://img.shields.io/badge/Cookiecutter-snekpack-blue"/></a>
     <a href='https://github.com/psf/black'>
-        <img src='https://img.shields.io/badge/code%20style-black-000000.svg' alt='Code style: black'/>
-    </a>
+        <img src='https://img.shields.io/badge/code%20style-black-000000.svg' alt='Code style: black'/></a>
     <a href="https://github.com/pseudopotential-tools/oncvpsp-tools/blob/main/.github/CODE_OF_CONDUCT.md">
-        <img src="https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg" alt="Contributor Covenant"/>
-    </a>
+        <img src="https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg" alt="Contributor Covenant"/></a>
 </p>
 
 Tools for handling input and output files of ``oncvpsp.x``

--- a/README.md
+++ b/README.md
@@ -10,28 +10,28 @@
 
 <p align="center">
     <a href="https://github.com/pseudopotential-tools/oncvpsp-tools/actions/workflows/tests.yml">
-        <img alt="Tests" src="https://github.com/pseudopotential-tools/oncvpsp-tools/workflows/Tests/badge.svg" />
+        <img alt="Tests" src="https://github.com/pseudopotential-tools/oncvpsp-tools/workflows/Tests/badge.svg"/>
     </a>
     <a href="https://pypi.org/project/oncvpsp_tools">
-        <img alt="PyPI" src="https://img.shields.io/pypi/v/oncvpsp-tools" />
+        <img alt="PyPI" src="https://img.shields.io/pypi/v/oncvpsp-tools"/>
     </a>
     <a href="https://pypi.org/project/oncvpsp_tools">
-        <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/oncvpsp-tools" />
+        <img alt="PyPI - Python Version" src="https://img.shields.io/pypi/pyversions/oncvpsp-tools"/>
     </a>
     <a href="https://github.com/pseudopotential-tools/oncvpsp-tools/blob/main/LICENSE">
-        <img alt="PyPI - License" src="https://img.shields.io/pypi/l/oncvpsp-tools" />
+        <img alt="PyPI - License" src="https://img.shields.io/pypi/l/oncvpsp-tools"/>
     </a>
     <a href='https://oncvpsp_tools.readthedocs.io/en/latest/?badge=latest'>
-        <img src='https://readthedocs.org/projects/oncvpsp_tools/badge/?version=latest' alt='Documentation Status' />
+        <img src='https://readthedocs.org/projects/oncvpsp_tools/badge/?version=latest' alt='Documentation Status'/>
     </a>
     <a href="https://codecov.io/gh/pseudopotential-tools/oncvpsp-tools/branch/main">
-        <img src="https://codecov.io/gh/pseudopotential-tools/oncvpsp-tools/branch/main/graph/badge.svg" alt="Codecov status" />
+        <img src="https://codecov.io/gh/pseudopotential-tools/oncvpsp-tools/branch/main/graph/badge.svg" alt="Codecov status"/>
     </a>  
     <a href="https://github.com/cthoyt/cookiecutter-python-package">
-        <img alt="Cookiecutter template from @cthoyt" src="https://img.shields.io/badge/Cookiecutter-snekpack-blue" /> 
+        <img alt="Cookiecutter template from @cthoyt" src="https://img.shields.io/badge/Cookiecutter-snekpack-blue"/> 
     </a>
     <a href='https://github.com/psf/black'>
-        <img src='https://img.shields.io/badge/code%20style-black-000000.svg' alt='Code style: black' />
+        <img src='https://img.shields.io/badge/code%20style-black-000000.svg' alt='Code style: black'/>
     </a>
     <a href="https://github.com/pseudopotential-tools/oncvpsp-tools/blob/main/.github/CODE_OF_CONDUCT.md">
         <img src="https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg" alt="Contributor Covenant"/>


### PR DESCRIPTION
Fixing README badges, including switching underscores for dashes in ``upf-tools``, adding codecov, and removing rogue spaces in hyperlinks that were appearing as underscores