### PR TITLE
Support ONCVPSP v3 output format for wavefunctions

### DIFF
--- a/src/oncvpsp_tools/output.py
+++ b/src/oncvpsp_tools/output.py
@@ -237,7 +237,7 @@ class ONCVPSPOutput:
         )
         kinds = ["full", "pseudo"]
         kwargs = [
-            {"info": {"kind": kind, "i": int(il[0]), "l": int(il[1])}}
+            {"info": {"kind": kind, "i": int(il[0]) if len(il) == 2 else 1, "l": int(il[1]) if len(il) == 2 else int(il[0])}}
             for il in il_pairs
             for kind in kinds
         ]

--- a/src/oncvpsp_tools/output.py
+++ b/src/oncvpsp_tools/output.py
@@ -241,7 +241,7 @@ class ONCVPSPOutput:
             for il in il_pairs
             for kind in kinds
         ]
-        identifiers = ["&    " + il for il in il_pairs for _ in kinds]
+        identifiers = [f"&{il:>6s}" for il in il_pairs for _ in kinds]
         ycols = [kind_col for _ in range(len(il_pairs)) for kind_col in [3, 4]]
         wavefunctions = ONCVPSPOutputDataList.from_str(
             "wavefunctions", content, identifiers, 2, ycols, kwargs


### PR DESCRIPTION
I tried parsing one of the ONCVPSP v3(.2.3.1 04/28/2017) output files from the PseudoDojo (e.g. [this one](https://github.com/PseudoDojo/ONCVPSP-PBE-PDv0.4/blob/134d757178552b8228a43a848b0e53f232cdda84/Si/Si.out)), and the parser failed when constructing the `kwargs` for the pseudo and all-electron wavefunctions.

It seems like this is because it expects two integers in the first data column (e.g. `12 -> i=1, l=2`).
This version of the code only seems to print `l` and not `i`; I just add a check for the length of the `il` string and set `i=1` if `len(il)=1`.
