### PR TITLE
Parse the radius at which the logarithmic derivatives are calculated

### DIFF
--- a/src/oncvpsp_tools/output.py
+++ b/src/oncvpsp_tools/output.py
@@ -248,9 +248,15 @@ class ONCVPSPOutput:
         )
 
         # Arctan log derivatives
+        r_values = {  # second line looks like this: atan(r * ((d psi(r)/dr)/psi(r))), r=
+            int(line.strip().split()[-1]): float(splitcontent[i+1].strip().split()[-1])
+            for i, line in enumerate(splitcontent)
+            if line.strip().startswith("log derivativve data for plotting, l=")
+        }
+        kinds = ["full", "pseudo"]
         identifiers = [f"!      {l}" for l in range(4) for kind in kinds]
         ycols = [kind_col for _ in range(4) for kind_col in [3, 4]]
-        kwargs = [{"info": {"kind": kind, "l": l}} for l in range(4) for kind in kinds]
+        kwargs = [{"info": {"kind": kind, "l": l, "r": r_values[l]}} for l in range(4) for kind in kinds]
         arctan_log_derivatives = ONCVPSPOutputDataList.from_str(
             "arctan log derivatives", content, identifiers, 2, ycols, kwargs
         )


### PR DESCRIPTION
ONCVPSP automatically determines a values of `R` at which to compute the logarithmic derivatives (log-ders) of the pseudo and all-electron wavefunctions:

```math
\phi(E) = \mathrm{arctan} \left[ R \frac{d\psi}{dr} \psi^{-1} \right]
```

This is a relatively important piece of information when interpreting the results.
Each block of the log-der outputs looks like this [sic]:
```
log derivativve data for plotting, l= {l:d}
atan(r * ((d psi(r)/dr)/psi(r))), r= {r:f}
l, energy, all-electron, pseudopotential
{empty line}
!    l   e   ae   ps
         .
         .
         .
```

I go through and look for all the lines starting with `log derivativve ...` and pull out the values for `l` and `r` then inject them in the `kwargs` by using `l` as a reference key.